### PR TITLE
Refactored poomf.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,27 @@ puush-like functionality for pomf.se
 
 ![](http://a.pomf.se/avnmcn.png)
 
-usage
+Usage
 =====
 
--f for fullscreen capture, -s for a selection rectangle, and -u 'file' to upload a file
+`-f` for fullscreen capture, `-s` for a selection rectangle, and `-u <file>` to upload a file.
 
-for best results, bind each operation to a hotkey using sxhkd or xbindkeys
+For best results, bind each operation to a hotkey using `sxhkd` or `xbindkeys`.
 
-requirements
+Requirements
 ============
 
 - curl
 - libnotify (for notifications)
 - maim (for screenshot)
 - slop (for selection capture)
-- xclip (for auto-copy)
+- xclip (for clip-board support)
 
-
-credit
+Credit
 ======
 
-inspired by onodera-punpun's pomf.sh (https://github.com/onodera-punpun)
+Inspired by [onodera-punpun](https://github.com/onodera-punpun)'s pomf.sh
 
-upload functionality by kittykatt (https://github.com/KittyKatt)
+Original upload functionality by [KittyKatt](https://github.com/KittyKatt)
+
+**New** upload functionality and refactoring by [arianon](https://github.com/arianon)

--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@ for best results, bind each operation to a hotkey using sxhkd or xbindkeys
 requirements
 ============
 
-curl
-
-libnotify (for notifications)
-
-maim (for screenshot)
-
-slop (for selection capture)
-
-xclip (for auto-copy)
+- curl
+- libnotify (for notifications)
+- maim (for screenshot)
+- slop (for selection capture)
+- xclip (for auto-copy)
 
 
 credit


### PR DESCRIPTION
Changes
======
- Use gyazo response of pomf.se for much cleaner parsing, thanks to [cenci0](http://github.com/cenci0) and [nokonoko](https://github.com/nokonoko).
- Better help with usage() function.
- More POSIX-compliant help message (although perhaps not completely).
- Cleaner use of getopts.
- Use a for loop instead of a while loop.
- Use echo instead of printf.
- Other minor changes.

By the way, after you merge this you'll probably want to update the screenshot.